### PR TITLE
Fixing the default value for the SSMParameter

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -8,7 +8,7 @@ Parameters:
     MaxLength: 250
   SSMParameterPath:
     Type: String
-    Default: 'lambda-stripe-charge/stripe-secret-key'
+    Default: '/lambda-stripe-charge/stripe-secret-key'
     Description: >
       This component assumes the Stripe Secret key needed to use the Stripe Charge API is stored as SecureStrings in SSM Parameter Store under the path defined by
       this parameter. See the component README for details.

--- a/template.yaml
+++ b/template.yaml
@@ -12,7 +12,7 @@ Parameters:
     Description: >
       This component assumes the Stripe Secret key needed to use the Stripe Charge API is stored as SecureStrings in SSM Parameter Store under the path defined by
       this parameter. See the component README for details.
-    AllowedPattern: ^[0-9a-zA-Z-][0-9a-zA-Z-\/]+
+    AllowedPattern: ^/[0-9a-zA-Z-][0-9a-zA-Z-\/]+
     ConstraintDescription: 'Must start with a slash and alphanumeric characters (exclude the starting slash)'
   EnableInstantCapture:
     Type: String


### PR DESCRIPTION
This causes some role issues if defaulting to this value as the SSM Parameter is required to be a fully qualified name.