### PR TITLE
#16 Moved SSM parameter retrieval outside of handler

### DIFF
--- a/charge.js
+++ b/charge.js
@@ -4,7 +4,8 @@ const AWS = require('aws-sdk'),
   processResponse = require('./src/process-response'),
   createCharge = require('./src/create-charge'),
   STRIPE_SECRET_KEY_NAME = `/${process.env.SSM_PARAMETER_PATH}`,
-  IS_CORS = true;
+  IS_CORS = true,
+  stripeSecretKeyValue = ssm.getParameter({ Name: STRIPE_SECRET_KEY_NAME, WithDecryption: true });
 
 exports.handler = (event) => {
   if (event.httpMethod === 'OPTIONS') {
@@ -13,17 +14,13 @@ exports.handler = (event) => {
   if (!event.body) {
     return Promise.resolve(processResponse(IS_CORS, 'invalid', 400));
   }
-  
+
   const chargeRequest = typeof event.body == 'object' ? event.body : JSON.parse(event.body);
   if (!chargeRequest.amount || !chargeRequest.currency) {
     return Promise.resolve(processResponse(IS_CORS, 'invalid arguments, please provide amount and currency fields as mentioned in the app README', 400));
   }
 
-  return ssm.getParameter({ Name: STRIPE_SECRET_KEY_NAME, WithDecryption: true }).promise()
-    .then(response => {
-      const stripeSecretKeyValue = response.Parameter.Value;
-      return createCharge(stripeSecretKeyValue, chargeRequest.stripeToken, chargeRequest.email, chargeRequest.amount, chargeRequest.currency, chargeRequest.description);
-    })
+  return createCharge(stripeSecretKeyValue.Parameter.value, chargeRequest.stripeToken, chargeRequest.email, chargeRequest.amount, chargeRequest.currency, chargeRequest.description)
     .then(createdCharge => processResponse(IS_CORS, { createdCharge }))
     .catch((err) => {
       console.log(err);

--- a/refund.js
+++ b/refund.js
@@ -3,7 +3,8 @@ const AWS = require('aws-sdk'),
   processResponse = require('./src/process-response'),
   createRefund = require('./src/create-refund'),
   STRIPE_SECRET_KEY_NAME = `/${process.env.SSM_PARAMETER_PATH}`,
-  IS_CORS = true;
+  IS_CORS = true,
+  stripeSecretKeyValue = ssm.getParameter({ Name: STRIPE_SECRET_KEY_NAME, WithDecryption: true });
 
 exports.handler = (event) => {
   if (event.httpMethod === 'OPTIONS') {
@@ -18,11 +19,7 @@ exports.handler = (event) => {
     return Promise.resolve(processResponse(IS_CORS, 'invalid arguments, please provide the chargeId (its ID) as mentioned in the app README', 400));
   }
 
-  return ssm.getParameter({ Name: STRIPE_SECRET_KEY_NAME, WithDecryption: true }).promise()
-    .then(response => {
-      const stripeSecretKeyValue = response.Parameter.Value;
-      return createRefund(stripeSecretKeyValue, refundRequest.chargeId, refundRequest.email);
-    })
+  return createRefund(stripeSecretKeyValue.Parameter.Value, refundRequest.chargeId, refundRequest.email)
     .then(createdRefund => processResponse(IS_CORS, { createdRefund }))
     .catch((err) => {
       console.log(err);


### PR DESCRIPTION
Moved the retrieval of the parameters from SSM outside of the lambda handler to reduce the number of requests to SSM and very slightly speed up the execution. The only downside, if the Stripe key is changed it will take up to 15 minutes until all lambda instances use the correct key, but Stripe keys should be quite permanent,