### PR TITLE
#17 Exposed stripe configuration options

### DIFF
--- a/src/payment-processor.js
+++ b/src/payment-processor.js
@@ -6,10 +6,16 @@ const { captureAsyncFunc } = require('./tracing-repository'),
   CREATE_REFUND_MESSAGE_TRACE = 'Create Refund';
 
 module.exports = {
-  createCharge: async function (stripeSecretKey, token, amount, currency, isCapture, description = 'Charge Description'){
-    const stripe = require('stripe')(stripeSecretKey);
-
-    return await captureAsyncFunc(CREATE_CHARGE_MESSAGE_TRACE, () => 
+  createCharge: async function (stripeSecretKey, token, amount, currency, isCapture, description = 'Charge Description') {
+    const stripe = require('stripe')(stripeSecretKey, {
+      'apiVersion': (process.env.API_VERSION == "null") ? null : process.env.API_VERSION,
+      'maxNetworkRetries': process.env.MAX_NETWORK_RETRIES,
+      'httpAgent': null,
+      'timeout': process.env.TIMEOUT,
+      'host': process.env.HOST,
+      'port': process.env.PORT,
+      'telemetry': process.env.TELEMETRY});
+    return await captureAsyncFunc(CREATE_CHARGE_MESSAGE_TRACE, () =>
       stripe.charges.create({
         source: token,
         amount: amount,
@@ -19,12 +25,28 @@ module.exports = {
       })
     );
   },
-  captureCharge: async function (stripeSecretKey, charge){
-    const stripe = require('stripe')(stripeSecretKey);
+  captureCharge: async function (stripeSecretKey, charge) {
+    const stripe = require('stripe')(stripeSecretKey,
+      (process.env.API_VERSION == "null") ? null : process.env.API_VERSION,
+      process.env.MAX_NETWORK_RETRIES,
+      null,
+      process.env.TIMEOUT,
+      process.env.HOST,
+      process.env.PORT,
+      process.env.PROTOCOL,
+      process.env.TELEMETRY);
     return await captureAsyncFunc(CAPTURE_CHARGE_MESSAGE_TRACE, () => stripe.charges.capture(charge));
   },
   createRefund: async function (stripeSecretKey, charge) {
-    const stripe = require('stripe')(stripeSecretKey);
-    return await captureAsyncFunc(CREATE_REFUND_MESSAGE_TRACE, () => stripe.refunds.create({charge}));
+    const stripe = require('stripe')(stripeSecretKey,
+      (process.env.API_VERSION == "null") ? null : process.env.API_VERSION,
+      process.env.MAX_NETWORK_RETRIES,
+      null,
+      process.env.TIMEOUT,
+      process.env.HOST,
+      process.env.PORT,
+      process.env.PROTOCOL,
+      process.env.TELEMETRY);
+    return await captureAsyncFunc(CREATE_REFUND_MESSAGE_TRACE, () => stripe.refunds.create({ charge }));
   }
 };

--- a/src/payment-processor.js
+++ b/src/payment-processor.js
@@ -14,7 +14,8 @@ module.exports = {
       'timeout': process.env.TIMEOUT,
       'host': process.env.HOST,
       'port': process.env.PORT,
-      'telemetry': process.env.TELEMETRY});
+      'telemetry': process.env.TELEMETRY
+    });
     return await captureAsyncFunc(CREATE_CHARGE_MESSAGE_TRACE, () =>
       stripe.charges.create({
         source: token,
@@ -26,27 +27,27 @@ module.exports = {
     );
   },
   captureCharge: async function (stripeSecretKey, charge) {
-    const stripe = require('stripe')(stripeSecretKey,
-      (process.env.API_VERSION == "null") ? null : process.env.API_VERSION,
-      process.env.MAX_NETWORK_RETRIES,
-      null,
-      process.env.TIMEOUT,
-      process.env.HOST,
-      process.env.PORT,
-      process.env.PROTOCOL,
-      process.env.TELEMETRY);
+    const stripe = require('stripe')(stripeSecretKey, {
+      'apiVersion': (process.env.API_VERSION == "null") ? null : process.env.API_VERSION,
+      'maxNetworkRetries': process.env.MAX_NETWORK_RETRIES,
+      'httpAgent': null,
+      'timeout': process.env.TIMEOUT,
+      'host': process.env.HOST,
+      'port': process.env.PORT,
+      'telemetry': process.env.TELEMETRY
+    });
     return await captureAsyncFunc(CAPTURE_CHARGE_MESSAGE_TRACE, () => stripe.charges.capture(charge));
   },
   createRefund: async function (stripeSecretKey, charge) {
-    const stripe = require('stripe')(stripeSecretKey,
-      (process.env.API_VERSION == "null") ? null : process.env.API_VERSION,
-      process.env.MAX_NETWORK_RETRIES,
-      null,
-      process.env.TIMEOUT,
-      process.env.HOST,
-      process.env.PORT,
-      process.env.PROTOCOL,
-      process.env.TELEMETRY);
+    const stripe = require('stripe')(stripeSecretKey, {
+      'apiVersion': (process.env.API_VERSION == "null") ? null : process.env.API_VERSION,
+      'maxNetworkRetries': process.env.MAX_NETWORK_RETRIES,
+      'httpAgent': null,
+      'timeout': process.env.TIMEOUT,
+      'host': process.env.HOST,
+      'port': process.env.PORT,
+      'telemetry': process.env.TELEMETRY
+    });
     return await captureAsyncFunc(CREATE_REFUND_MESSAGE_TRACE, () => stripe.refunds.create({ charge }));
   }
 };

--- a/template.yaml
+++ b/template.yaml
@@ -26,6 +26,32 @@ Parameters:
     AllowedValues: [true, false]
     Default: true
     Description: To immediatelly capture a payment upon charge, if true it means on charge you collect the amount, if false, you need to do a capture.
+  ApiVersion:
+    Type: String
+    Default: "null"
+    Description: Stripe API version to be used. If not set the account's default version will be used.
+  MaxNetworkRetries:
+    Type: Number
+    Default: 0
+    Description: The amount of times a request should be retried.
+  Timeout:
+    Type: Number
+    Default: 80000
+    Description: Maximum time each request can take in ms.
+  Host:
+    Type: String
+    Default: "api.stripe.com"
+    Description: Host that requests are made to.
+  Port:
+    Type: String
+    Default: 443
+    Description: Port that requests are made to.
+  Telemetry:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: Allow Stripe to send latency telemetry.
+
 Conditions:
   ShouldEnableCapture: !Equals [true, !Ref EnableInstantCapture]
 Resources:
@@ -56,6 +82,12 @@ Resources:
           SSM_PARAMETER_PATH: !Ref SSMParameterPath
           TOPIC_ARN: !Ref SNSTopic
           IS_CAPTURE: !Ref EnableInstantCapture
+          API_VERSION: !Ref ApiVersion
+          MAX_NETWORK_RETRIES: !Ref MaxNetworkRetries
+          TIMEOUT: !Ref Timeout
+          HOST: !Ref Host
+          PORT: !Ref Port
+          TELEMETRY: !Ref Telemetry
       Events:
         Api:
           Type: Api
@@ -78,6 +110,12 @@ Resources:
           CORS_ORIGIN: !Ref CorsOrigin
           SSM_PARAMETER_PATH: !Ref SSMParameterPath
           TOPIC_ARN: !Ref SNSTopic
+          API_VERSION: !Ref ApiVersion
+          MAX_NETWORK_RETRIES: !Ref MaxNetworkRetries
+          TIMEOUT: !Ref Timeout
+          HOST: !Ref Host
+          PORT: !Ref Port
+          TELEMETRY: !Ref Telemetry
       Events:
         Api:
           Type: Api
@@ -100,6 +138,12 @@ Resources:
           CORS_ORIGIN: !Ref CorsOrigin
           SSM_PARAMETER_PATH: !Ref SSMParameterPath
           TOPIC_ARN: !Ref SNSTopic
+          API_VERSION: !Ref ApiVersion
+          MAX_NETWORK_RETRIES: !Ref MaxNetworkRetries
+          TIMEOUT: !Ref Timeout
+          HOST: !Ref Host
+          PORT: !Ref Port
+          TELEMETRY: !Ref Telemetry
       Events:
         Api:
           Type: Api


### PR DESCRIPTION
Added six new cloud formation parameters: 
* `ApiVersion`
* `MaxNetworkRetries`
* `Timeout`
* `Host`
* `Port`
* `Telemetry`

that correspond to the [configuration options](https://github.com/stripe/stripe-node) of the stripe library. The parameters are passed as environment parameters to the lambda functions, which in turn pass them to the stripe library upon initialization. 

The following two configuration options are not exposed:
* `httpAgent`: This gets passed a JS object which is hard to do in cloud formation, outside of defining a few fixed options.
* `protocol`: It seems that this parameter is not supported by the stripe library version we are using. Also, stripe discourages the usage of this parameter.

I've tested that changes in the environment variables for `ApiVersion`, `Host`, and `Port`, are successfully propagated to the underlying library. For `MaxNetworkRetries`, `Timeout`, and `Telemetry` it's hard to figure out if they are successfully propagated to the library, but I don't see why they would not work. Especially, since the stripe library complains if an unknown configuration option is supplied.

I hope that this is the correct way of exposing parameters for SAR applications, I've used ´EnableInstantCapture´ as a guideline.
