### PR TITLE
fix: upgrade to nodejs 14 runtime

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -3,7 +3,7 @@ Transform: AWS::Serverless-2016-10-31
 
 Globals:
   Function:
-    Runtime: nodejs10.x
+    Runtime: nodejs14.x
     Timeout: 10
     Tracing: Active
 


### PR DESCRIPTION
Fixes: https://github.com/aws-samples/aws-serverless-airline-booking/issues/172

Nodejs10.x is officially deprecated and this fails the SAR App deployment: https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:375983427419:applications~api-lambda-stripe-charge

Signed-off-by: heitorlessa <lessa@amazon.co.uk>